### PR TITLE
Fix crash on next hand after scoring naneinf

### DIFF
--- a/MikasModCollection.lua
+++ b/MikasModCollection.lua
@@ -6112,6 +6112,10 @@ end
 -- Calculate Chips
 local evaluate_playref = G.FUNCS.evaluate_play
 function G.FUNCS.evaluate_play(self, e)
+    if not G.GAME.round_scores['hand'].amt or type(G.GAME.round_scores['hand'].amt) ~= "number" then
+        G.GAME.round_scores['hand'].amt = 0
+    end
+
     evaluate_playref(self, e)
 
     for i = 1, #G.jokers.cards do


### PR DESCRIPTION
After having scored "naneinf" (infinity) in a round, playing a hand in the next round would crash the game. Another mod may have been partly to blame (I saw Bunco was in the stack trace), but adding a failsafe here prevents the crash.